### PR TITLE
Sets a default statusCode of 200 for all API Gateway requests

### DIFF
--- a/src/LambdaReq.js
+++ b/src/LambdaReq.js
@@ -158,7 +158,7 @@ class LambdaReq {
   _respondToApiGateway (error, response) {
     log('handling APIGateway response: %s %o', error, response)
     
-    let statusCode
+    let statusCode = 200;
     
     if (error) {
       statusCode = 500

--- a/src/LambdaReq.js
+++ b/src/LambdaReq.js
@@ -158,7 +158,7 @@ class LambdaReq {
   _respondToApiGateway (error, response) {
     log('handling APIGateway response: %s %o', error, response)
     
-    let statusCode = 200;
+    let statusCode = 200
     
     if (error) {
       statusCode = 500

--- a/tests/unit/LambdaReq.js
+++ b/tests/unit/LambdaReq.js
@@ -43,6 +43,7 @@ describe('LambdaReq', () => {
           lambda
         )).eql(true)
         should(callback.getCall(0).args[1]).containEql({
+          statusCode: 200,
           body: '{"success":true}'
         })
       })
@@ -62,6 +63,7 @@ describe('LambdaReq', () => {
               lambda
             )).eql(true)
             should(callback.getCall(0).args[1]).containEql({
+              statusCode: 200,
               body: '{"success":true}'
             })
           })


### PR DESCRIPTION
### Problem
For all API Gateway requests, a statusCode is currently only sent if it's an error. This is because the only thing developers have access to when handling a route is the response body (which is stringified and placed on the response [here](https://github.com/doomhz/node-lambda-req/blob/master/src/LambdaReq.js#L186)).

### Proposed Solution
Given that any error sets the `statusCode` accordingly, it should be safe to assume a default `statusCode` of 200.

### This PR does the following
* Sets a default value for the `statusCode` of 200 when handling API Gateway requests
* Updates the corresponding unit tests to ensure that the response also includes the `statusCode`