### PR TITLE
Support for x-www-form-urlencoded / Multipart

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "sinon": "^2.0.0"
   },
   "dependencies": {
+    "busboy": "^0.2.14",
     "debug": "^2.6.3"
   },
   "nyc": {

--- a/src/LambdaReq.js
+++ b/src/LambdaReq.js
@@ -73,7 +73,6 @@ class LambdaReq {
     this._event = event
     this._context = context
     this._callback = callback
-    console.log(this.headers)
     const busboy = new Busboy({ headers: this.headers })
     this._busboy = busboy
     console.assert(typeof event === 'object' && event !== null, 'Malformed Lambda event object.')

--- a/src/LambdaReq.js
+++ b/src/LambdaReq.js
@@ -134,30 +134,31 @@ class LambdaReq {
   _parseApiGatewayBody(contentType = 'application/json', event) {
     const body = {}
     if (contentType.toLowerCase() === 'application/json') {
-        Object.assign(body, JSON.parse(event.body));
+        Object.assign(body, JSON.parse(event.body))
     } else if (contentType.toLowerCase() === 'application/x-www-form-urlencoded') {
-        const pieces = {};
+        const pieces = {}
         event.body.split('&').forEach(part => {
-          const keyValue = part.split('=');
-          pieces[keyValue[0]] = keyValue[1];
-        });
-        Object.assign(body, pieces);
+          const keyValue = part.split('=')
+          pieces[keyValue[0]] = keyValue[1]
+        })
+        Object.assign(body, pieces)
     // multipart is server on the busboy event
     } else if (!/multipart/.test(contentType)) {
         try {
-          Object.assign(body, JSON.parse(event.body));
+          Object.assign(body, JSON.parse(event.body))
         } catch(e) {
+          //
         }
     }
 
-    return body;
+    return body
   }
 
   _parseApiGatewayData (event = this._event) {
     const body = this._parseApiGatewayBody(
       event.headers['content-type'] || event.headers['Content-Type'],
       event
-    );
+    )
 
     return {
       method: event.httpMethod,

--- a/tests/unit/LambdaReq.js
+++ b/tests/unit/LambdaReq.js
@@ -36,12 +36,32 @@ describe('LambdaReq', () => {
         const lambda = new LambdaReq(API_GATEWAY_EVENT, {}, callback)
         lambda.get('/v1/test', handler)
         lambda.invoke()
-        should(handler.calledWith(
+        should(handler.calledWith(sinon.match(
           { params: { name: 'john', id: 'u-123', active: true },
             headers: { 'Content-Type': 'application/json' }
-          },
+          }),
           lambda
         )).eql(true)
+        should(callback.getCall(0).args[1]).containEql({
+          statusCode: 200,
+          body: '{"success":true}'
+        })
+      })
+
+      it('responds to x-www-form-urlencoded', () => {
+        const callback = sinon.stub()
+        const handler = sinon.stub().returns({ success: true })
+        const event =  Object.assign({}, API_GATEWAY_EVENT, {
+           headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+           },
+          body: 'active=true'
+        })
+
+        const lambda = new LambdaReq(event, {}, callback)
+        lambda.get('/v1/test', handler)
+        lambda.invoke()
+        
         should(callback.getCall(0).args[1]).containEql({
           statusCode: 200,
           body: '{"success":true}'
@@ -56,10 +76,10 @@ describe('LambdaReq', () => {
           lambda.get('/v1/test', handler)
           return lambda.invoke()
           .then(()=> {
-            should(handler.calledWith(
+            should(handler.calledWith(sinon.match(
               { params: { name: 'john', id: 'u-123', active: true },
                 headers: { 'Content-Type': 'application/json' }
-              },
+              }),
               lambda
             )).eql(true)
             should(callback.getCall(0).args[1]).containEql({
@@ -175,8 +195,8 @@ describe('LambdaReq', () => {
         const lambda = new LambdaReq(PROXY_EVENT, {}, callback)
         lambda.proxy('commandName', handler)
         lambda.invoke()
-        should(handler.calledWith(
-          { params: { id: 'u-123' }, headers: undefined },
+        should(handler.calledWith(sinon.match(
+          { params: { id: 'u-123' }, headers: undefined }),
           lambda
         )).eql(true)
         should(callback.getCall(0).args[1]).containEql('{"success":true}')


### PR DESCRIPTION
If the content-type header is set to `x-www-form-urlencoded` it tries to parse the data as a string such as `one=val&two=someothervalue` and returns the object:
```
{ 
  one: 'val',
  two: 'someothervalue'
}
```
Previously this broke because it always tried to parse as json.

Secondly if the content type is multipart im using [busboy](https://github.com/mscdex/busboy) and returning the `.on` method on the `req` variable (`(req, router) => {}`). You would then use a promise to access to the for data as such:
```javascript
  const lambda = new LambdaReq(event, context, callback);
  lambda.post('/message',  (req, router) => {
        const fields = {};
        return new Promise((resolve, reject) => {
            req.on('field', (fieldname, val, fieldnameTruncated, valTruncated, encoding, mimetype) => {
                console.log('test');
                console.log('Field [' + fieldname + ']: value: ' + inspect(val));
                fields[fieldname] = val;
            });

    
        req.on('file', function(fieldname, file, filename, encoding, mimetype) {
            console.log('File [' + fieldname + ']: filename: ' + filename + ', encoding: ' + encoding + ', mimetype: ' + mimetype);
            file.on('data', function(data) {
                console.log('File [' + fieldname + '] got ' + data.length + ' bytes');
            });
            req.on('end', function() {
                console.log('File [' + fieldname + '] Finished');
            });
        })


        req.on('error', (err) => {
            console.log(err);
        })

        req.on('finish', () =>{
            console.log("finished");
            //inspect(fields);
            resolve({test: 'some value'});
        });
        }).catch(e => {
            console.log(e)
        });

    });